### PR TITLE
✨ adds iphone x buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
   },
   "main": "src/CustomComponents.js",
   "dependencies": {
+    "create-react-class": "15.6.0",
     "fbjs": "~0.8.9",
     "immutable": "~3.7.6",
-    "create-react-class": "15.6.0",
     "prop-types": "^15.5.10",
+    "react-native-iphone-x-helper": "^1.0.3",
     "react-timer-mixin": "^0.13.2",
     "rebound": "^0.0.13"
   },

--- a/src/NavigatorNavigationBarStylesIOS.js
+++ b/src/NavigatorNavigationBarStylesIOS.js
@@ -30,12 +30,12 @@ import {
   I18nManager,
   PixelRatio,
 } from 'react-native';
-
+import { ifIphoneX } from 'react-native-iphone-x-helper'
 var buildStyleInterpolator = require('./buildStyleInterpolator');
 var merge = require('./merge');
 
 var SCREEN_WIDTH = Dimensions.get('window').width;
-var NAV_BAR_HEIGHT = 44;
+var NAV_BAR_HEIGHT = ifIphoneX(66, 44);
 var STATUS_BAR_HEIGHT = 20;
 var NAV_HEIGHT = NAV_BAR_HEIGHT + STATUS_BAR_HEIGHT;
 


### PR DESCRIPTION
It sucks they hard coded the toolbar height to 44.  

It sucks even more that they `overflow: 'hidden'` on it too. This causes clipping if we try to add extra height.

And this PR continues to suck because I'm hard coding the extra height for an iPhone X.

I just don't have time to switch over to `react-navigation` just yet.

